### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem "ransack"
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
 gem 'omniauth', '~>2.1.1'
+gem 'rails-i18n'

--- a/app/models/itinerary.rb
+++ b/app/models/itinerary.rb
@@ -6,5 +6,5 @@ class Itinerary < ApplicationRecord
     validates :place
   end
 
-  validates :transportation_id, numericality: { message: "must be selected"}
+  validates :transportation_id, numericality: { message: "を選択してください"}
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -2,11 +2,11 @@ class Pet < ApplicationRecord
   belongs_to :user, optional: true
   
   with_options presence: true do
-    validates :birthday, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be input yyyy-mm-dd' }
+    validates :birthday, format: { with: /\A\d{4}-\d{2}-\d{2}\z/ }
 
-    validates :name, format:  { with: /\A[ぁ-んァ-ヶ一-龥々ーa-zA-Z]+\z/} 
-    validates :breed, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/} 
+    validates :name, format:  { with: /\A[ぁ-んァ-ヶ一-龥々ーa-zA-Z]+\z/, message: "は全角文字または半角英字で入力してください"} 
+    validates :breed, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "は全角文字で入力してください"} 
   end
 
-  validates :size_id, numericality: {message: 'must be select' }
+  validates :size_id, numericality: {message: 'を選択してください' }
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -21,7 +21,7 @@ class Plan < ApplicationRecord
     validates :return_date
   end
   
-  with_options numericality: { other_than:1, message: "must be selected"} do
+  with_options numericality: { other_than:1, message: "を選択してください"} do
     validates :departure_id
     validates :destination_id
     validates :companion_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   validates :nickname, presence:true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ーa-zA-Z0-9]+\z/}
   
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
-  validates :password, format: {with: VALID_PASSWORD_REGEX, message: "must contain both letters and at least one number."}, on: :create
+  validates :password, format: {with: VALID_PASSWORD_REGEX, message: "は半角英数字混合で入力してください"}, on: :create
 
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,41 @@ ja:
       short: "%Y/%m/%d"
       only_date: "%m/%d"
       only_time: "%H:%M"
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+      pet:
+        name: お名前
+        breed: 犬種
+        birthday: 誕生日
+        size_id: サイズ
+      plan:
+        title: タイトル
+        departure_date: 出発日
+        return_date: 帰着日
+        departure_id: 出発地
+        destination_id: 目的地
+        companion_id: 同伴者
+        pet: 同行わんこ
+        user: ユーザー
+      plan/itineraries:
+          memo: メモ
+          date: 日付
+          place: スポット名
+          transportation_id: 交通手段
+          plan: 旅行日程
+      itinerary:
+          memo: メモ
+          date: 日付
+          place: スポット名
+          transportation_id: 交通手段
+          plan: 旅行日程
+
+
+
+
+
+      
+
+

--- a/spec/models/itinerary_spec.rb
+++ b/spec/models/itinerary_spec.rb
@@ -20,22 +20,22 @@ RSpec.describe Itinerary, type: :model do
       it '日付と時刻を入力していない場合' do
         @itinerary.date = nil
         @itinerary.valid?
-        expect(@itinerary.errors.full_messages).to include("Date can't be blank")
+        expect(@itinerary.errors.full_messages).to include("日付を入力してください")
       end
       it '場所を入力していない場合' do
         @itinerary.place = nil
         @itinerary.valid?
-        expect(@itinerary.errors.full_messages).to include("Place can't be blank")
+        expect(@itinerary.errors.full_messages).to include("スポット名を入力してください")
       end
       it '移動手段を入力していない場合' do
         @itinerary.transportation_id = nil
         @itinerary.valid?
-        expect(@itinerary.errors.full_messages).to include("Transportation must be selected")
+        expect(@itinerary.errors.full_messages).to include("交通手段を選択してください")
       end
       it 'planが紐づいていない場合' do
         @itinerary.plan = nil
         @itinerary.valid?
-        expect(@itinerary.errors.full_messages).to include("Plan must exist")
+        expect(@itinerary.errors.full_messages).to include("旅行日程を入力してください")
       end
     end
   end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -16,47 +16,47 @@ RSpec.describe Pet, type: :model do
       it 'nameが空の場合' do
         @pet.name = ''
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Name can't be blank")
+        expect(@pet.errors.full_messages).to include("お名前を入力してください")
       end
       it 'nameに半角カタカナが含まれる場合' do
         @pet.name = 'ﾎﾟﾁ'
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Name is invalid")
+        expect(@pet.errors.full_messages).to include("お名前は全角文字または半角英字で入力してください")
       end
       it 'nameに半角数字が含まれる場合' do
         @pet.name = 'ポチ111'
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Name is invalid")
+        expect(@pet.errors.full_messages).to include("お名前は全角文字または半角英字で入力してください")
       end
       it 'breedが空の場合' do
         @pet.breed = ''
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Breed can't be blank")
+        expect(@pet.errors.full_messages).to include("犬種を入力してください")
       end
       it 'breedに半角カタカナが含まれる場合' do
         @pet.breed = 'ｼﾊﾞｹﾝ'
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Breed is invalid")
+        expect(@pet.errors.full_messages).to include("犬種は全角文字で入力してください")
       end
       it 'breedに半角英字が含まれる場合' do
         @pet.breed = 'shiba'
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Breed is invalid")
+        expect(@pet.errors.full_messages).to include("犬種は全角文字で入力してください")
       end
       it 'breedに半角数字が含まれる場合' do
         @pet.breed = 'sh1ba'
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Breed is invalid")
+        expect(@pet.errors.full_messages).to include("犬種は全角文字で入力してください")
       end
       it 'sizeが空の場合' do
         @pet.size_id = ''
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Size must be select")
+        expect(@pet.errors.full_messages).to include("サイズを選択してください")
       end
       it 'birthdayが空の場合' do
         @pet.birthday = ''
         @pet.valid?
-        expect(@pet.errors.full_messages).to include("Birthday can't be blank")
+        expect(@pet.errors.full_messages).to include("誕生日を入力してください")
       end
     end
   end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -26,42 +26,42 @@ RSpec.describe Plan, type: :model do
       it 'タイトルが空の場合' do
         @plan.title = ""
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Title can't be blank")
+        expect(@plan.errors.full_messages).to include("タイトルを入力してください")
       end
       it '出発日が空の場合' do
         @plan.departure_date = nil
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Departure date can't be blank")
+        expect(@plan.errors.full_messages).to include("出発日を入力してください")
       end
       it '帰着日が空の場合' do
         @plan.return_date = nil
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Return date can't be blank")
+        expect(@plan.errors.full_messages).to include("帰着日を入力してください")
       end
-      it '出発日が未選択の場合' do
+      it '出発地が未選択の場合' do
         @plan.departure_id = 1
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Departure must be selected")
+        expect(@plan.errors.full_messages).to include("出発地を選択してください")
       end
       it '目的地が未選択の場合' do
         @plan.destination_id = 1
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Destination must be selected")
+        expect(@plan.errors.full_messages).to include("目的地を選択してください")
       end
       it '同伴者が未選択の場合' do
         @plan.companion_id = 1
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Companion must be selected")
+        expect(@plan.errors.full_messages).to include("同伴者を選択してください")
       end
       it '同伴わんこが選択されていない場合' do
         @plan.pet = nil
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("Pet must exist")
+        expect(@plan.errors.full_messages).to include("同行わんこを入力してください")
       end
       it 'userが紐づいていない場合' do
         @plan.user = nil
         @plan.valid?
-        expect(@plan.errors.full_messages).to include("User must exist")
+        expect(@plan.errors.full_messages).to include("ユーザーを入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,75 +16,75 @@ RSpec.describe User, type: :model do
       it 'nicknameが空の場合' do
         @user.nickname = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it 'nicknameが半角カタカナの場合' do
         @user.nickname = 'ﾀﾛｳ'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname is invalid")
+        expect(@user.errors.full_messages).to include("ニックネームは不正な値です")
       end
       it 'nicknameに記号が含まれる場合' do
         @user.nickname = '太郎@'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname is invalid")
+        expect(@user.errors.full_messages).to include("ニックネームは不正な値です")
       end
       it 'nicknameに全角数字が含まれる場合' do
         @user.nickname = '太郎７７７'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname is invalid")
+        expect(@user.errors.full_messages).to include("ニックネームは不正な値です")
       end
       it 'nicknameに全角英字が含まれる場合' do
         @user.nickname = 'ｔａｒｏ'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname is invalid")
+        expect(@user.errors.full_messages).to include("ニックネームは不正な値です")
       end
       it 'emailが空の場合' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it 'emailが重複している場合' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include("Eメールはすでに存在します")
       end
       it 'emailに@が含まれない場合' do
         @user.email = "taro.test.com"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include("Eメールは不正な値です")
       end
       it 'passwordが空の場合' do
         @user.password = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'passwordが6文字未満の場合' do
         @user.password = "123ab"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
       it 'passwordが数字のみの場合' do
         @user.password = "123456"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password must contain both letters and at least one number.")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数字混合で入力してください")
       end
       it 'passwordが英字のみの場合' do
         @user.password = "abcdef"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password must contain both letters and at least one number.")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数字混合で入力してください")
       end
       it 'passwordに全角文字が含まれる場合' do
         @user.password = "１２３abc"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password must contain both letters and at least one number.")
+        expect(@user.errors.full_messages).to include("パスワードは半角英数字混合で入力してください")
       end
       it 'passwordと確認用passwordが一致しない場合' do
         @user.password = "abc123"
         @user.password_confirmation = "123abc"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
     end
   end


### PR DESCRIPTION
## what
既存テストコードのエラーメッセージ日本語化

## why
日本人ユーザーにとって使用しやすいようにするため。