### PR TITLE
Google maps apiの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,4 @@ gem "omniauth-rails_csrf_protection"
 gem 'omniauth', '~>2.1.1'
 gem 'rails-i18n'
 gem 'aws-sdk-s3'
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -392,6 +396,7 @@ DEPENDENCIES
   cocoon
   debug
   devise
+  dotenv-rails
   factory_bot_rails
   faker
   gon

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -2,6 +2,7 @@ class PlansController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_plan, only: [:show, :edit, :update, :destroy]
   before_action :check_user, only: [:edit, :update, :destroy]
+  before_action :import_apikey, only: [:new,:show]
 
   def index
     @plans = Plan.page(params[:page]).per(8).order("created_at DESC")
@@ -76,5 +77,9 @@ class PlansController < ApplicationController
     if current_user != @plan.user
       redirect_to root_path
     end
+  end
+
+  def import_apikey
+    gon.MAPID = ENV['MAPID']
   end
 end

--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -10,6 +10,7 @@ async function initMap() {
   if(!mapContent) return null;
   
   const { Map } = await google.maps.importLibrary("maps");
+  const { AdvancedMarkerElement } = await google.maps.importLibrary("marker");
   const spots = gon.spots;
   const hotel = gon.hotel;
   
@@ -21,9 +22,10 @@ async function initMap() {
 
   map = new Map(document.getElementById("map"), {
     center: tokyoStation,
-    zoom: 8
+    zoom: 8,
+    mapId: gon.MAPID
   });
-
+  
   if (spots != null) {
     for(let i = 0; i < spots.length; i++) {
       let latlng = {
@@ -34,14 +36,15 @@ async function initMap() {
       geocoder.geocode({ 'location': latlng }, function(results, status){
         if (status == 'OK') {
           map.setCenter(results[0].geometry.location);
-          marker[i] = new google.maps.Marker({
+
+          marker[i] = new google.maps.marker.AdvancedMarkerElement({
             map: map,
             position: results[0].geometry.location,
-            label: `${i + 1}`
+            title: `${i + 1}`
           })
-
           let address = results[0].formatted_address.split('、')
           infoWindow[i] = new google.maps.InfoWindow({
+            HeaderDisabled: true,
             content: `
                     <h1>${gon.spots[i].place}</h1>
                     <p>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -111,5 +111,9 @@
       </div>
   <% end %>
 </div>
-<script async src="https://maps.googleapis.com/maps/api/js?key=<%="#{ENV['GOOGLE_MAPS_API']}"%>&libraries=places">
+<script>
+  (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
+    key: "<%= ENV['GOOGLE_MAPS_API'] %>",
+    v: "weekly",
+  });
 </script>


### PR DESCRIPTION
# what
Google.map.markerの記述を[高度なマーカー](https://developers.google.com/maps/documentation/javascript/advanced-markers/migration?hl=ja)を用いた記述に移行。

# why
Google.map.markerのサポート終了のため。